### PR TITLE
Add default option to suppress writing the compiled Twig source map line comments

### DIFF
--- a/php/class-plugin.php
+++ b/php/class-plugin.php
@@ -83,6 +83,7 @@ class Plugin {
 			'loader_template_paths' => array(),
 			'vip_plugin_folders' => array( 'plugins' ), // On VIP, you may want to filter the config to add 'acmecorp-plugins'
 			'charset' => get_bloginfo( 'charset' ), // TODO: VIP should always by Latin1
+			'write_source_map_lines' => false, // whether or not to include `// line 123` in the compiled PHP
 		);
 
 		if ( $is_unit_testing ) {
@@ -142,6 +143,7 @@ class Plugin {
 
 		$this->twig_loader = new Twig_Loader( $this, $this->config['loader_template_paths'] );
 		$this->twig_environment = new Twig_Environment( $this, $this->twig_loader, $this->config['environment_options'] );
+		$this->twig_environment->setCompiler( new Twig_Compiler( $this, $this->twig_environment ) );
 		$this->render_caching = new Render_Caching( $this );
 
 		// Replace \Twig_Extension_Core with our subclass override

--- a/php/class-twig-compiler.php
+++ b/php/class-twig-compiler.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace VIP_Twig;
+
+class Twig_Compiler extends \Twig_Compiler {
+
+	/**
+	 * @var Plugin
+	 */
+	public $plugin;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Plugin $plugin
+	 * @param \Twig_Environment $env The twig environment instance
+	 */
+	public function __construct( Plugin $plugin, \Twig_Environment $env) {
+		$this->plugin = $plugin;
+		parent::__construct( $env );
+	}
+
+	/**
+	 * Adds debugging information.
+	 *
+	 * This is copied from the parent class, with the addition of a wrapper
+	 * around the write() call for outputting the Twig source line.
+	 *
+	 * @param \Twig_NodeInterface $node The related twig node
+	 *
+	 * @return Twig_Compiler The current compiler instance
+	 */
+	public function addDebugInfo( \Twig_NodeInterface $node ) {
+		if ( $node->getLine() !== $this->lastLine ) {
+			// Write out the source map files only if explicitly requested
+			if ( ! empty( $this->plugin->config['write_source_map_lines'] ) ) {
+				$this->write( sprintf( "// line %d\n", $node->getLine() ) );
+			}
+
+			/*
+			 * when mbstring.func_overload is set to 2
+			 * mb_substr_count() replaces substr_count()
+			 * but they have different signatures!
+			 */
+			if ( ( (int) ini_get( 'mbstring.func_overload' ) ) & 2 ) {
+				// this is much slower than the "right" version
+				$this->sourceLine += mb_substr_count( mb_substr( $this->source, $this->sourceOffset ), "\n" );
+			} else {
+				$this->sourceLine += substr_count( $this->source, "\n", $this->sourceOffset );
+			}
+			$this->sourceOffset = strlen( $this->source );
+			$this->debugInfo[ $this->sourceLine ] = $node->getLine();
+
+			$this->lastLine = $node->getLine();
+		}
+
+		return $this;
+	}
+
+}


### PR DESCRIPTION
Removes the `// line 123` from appearing in the compiled PHP unless explicitly called for (via config).