### PR TITLE
Document correct method that sets `$plugin_instance`

### DIFF
--- a/php/class-cli.php
+++ b/php/class-cli.php
@@ -8,7 +8,7 @@ namespace VIP_Twig;
 class CLI extends \WP_CLI_Command {
 
 	/**
-	 * This gets set by Plugin::__construct()
+	 * This gets set by Plugin->init()
 	 *
 	 * @var Plugin
 	 */

--- a/php/class-cli.php
+++ b/php/class-cli.php
@@ -8,8 +8,9 @@ namespace VIP_Twig;
 class CLI extends \WP_CLI_Command {
 
 	/**
-	 * This gets set by Plugin->init()
+	 * Plugin instance.
 	 *
+	 * @see Plugin::init() Where this variable gets set.
 	 * @var Plugin
 	 */
 	static public $plugin_instance;


### PR DESCRIPTION
Because `init()` sets this and not the `constructor`.